### PR TITLE
Add api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,42 @@
 ## Install
 
-### Dependencies
+### From pip
+
+First, install the dependencies:
+
+- [Snakemake 7.32](https://snakemake.readthedocs.io/en/v7.32.0/getting_started/installation.html)
+- [Ncbi-blast 2.16](https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.16.0/)
+- [Nextclade 3.15](https://docs.nextstrain.org/projects/nextclade/en/3.15.3/user/nextclade-cli/installation/)
+- [Seqtk 1.5](https://github.com/lh3/seqtk/releases/tag/v1.5)
+- [Python < 3.12](https://www.python.org/downloads/)
+
+or with micromamba
+
+```bash
+micromamba install -c conda-forge -c bioconda "snakemake-minimal>=7.32.0,<7.33.0" "blast>=2.16.0,<2.17.0" "nextclade>=3.15.0,<3.16.0" "seqtk>=1.5.0,<1.6.0"  "python>=3.8.0,<3.12.0"
+```
+
+Then, install viralQC
+
+```bash
+pip install viralQC
+```
+
+### From Source
+
+```bash
+git clone https://github.com/InstitutoTodosPelaSaude/viralQC.git
+cd viralQC
+```
+
+#### Dependencies
 
 ```bash
 micromamba env create -f env.yml
 micromamba activate viralQC
 ```
 
-### viralQC
+#### viralQC
 
 ```bash
 pip install .

--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@ First, install the dependencies:
 or with micromamba
 
 ```bash
-micromamba install -c conda-forge -c bioconda "snakemake-minimal>=7.32.0,<7.33.0" "blast>=2.16.0,<2.17.0" "nextclade>=3.15.0,<3.16.0" "seqtk>=1.5.0,<1.6.0"  "python>=3.8.0,<3.12.0"
+micromamba install \
+  -c conda-forge \
+  -c bioconda \
+  "python>=3.8.0,<3.12.0" \
+  "snakemake-minimal>=7.32.0,<7.33.0" \
+  "blast>=2.16.0,<2.17.0" \
+  "nextclade>=3.15.0,<3.16.0" \
+  "seqtk>=1.5.0,<1.6.0"
 ```
 
 Then, install viralQC

--- a/env.yml
+++ b/env.yml
@@ -8,7 +8,6 @@ channels:
 dependencies:
 - snakemake-minimal>=7.32.0,<7.33.0
 - blast>=2.16.0,<2.17.0
-- pandas>=2.2.0,<2.3.0
 - nextclade>=3.15.0,<3.16.0
 - python>=3.8.0,<3.12.0
 - seqtk>=1.5.0,<1.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "viralQC"
-version = "1.0.0"
-description = "A tool and package for quality assurance of consensus virus genomes."
+version = "0.1.0"
+description = "A tool and package for quality control of consensus virus genomes."
 authors = [
     { name = "Filipe Zimmer Dezordi", email = "zimmer.filipe@gmail.com" }
 ]
@@ -13,17 +13,20 @@ dependencies = [
     "fastapi>=0.116",
     "uvicorn[standard]>=0.35",
     "colorlog>=6.3",
-    "pyyaml>=6.0"
+    "pyyaml>=6.0",
+    "pandas>=2.2",
+    "python-multipart==0.0.20"
 ]
 
-keywords = ["virus", "quality-assurance", "python", "snakemake"]
+keywords = ["virus", "quality-control", "python", "snakemake"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",
     "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: Utilities"
+    "Topic :: Utilities",
+    "Development Status :: 3 - Alpha"
 ]
 
 [project.optional-dependencies]
@@ -33,7 +36,8 @@ cli = [
 ]
 api = [
     "fastapi>=0.116",
-    "uvicorn[standard]>=0.35"
+    "uvicorn[standard]>=0.35",
+    "python-multipart==0.0.20"
 ]
 all = [
     "vqc[cli,api]"
@@ -53,3 +57,6 @@ build-backend = "hatchling.build"
 
 [tool.setuptools.package-data]
 viralqc = ["config/nextclade_datasets.yml"]
+
+[project.urls]
+Homepage = "https://github.com/InstitutoTodosPelaSaude/viralQC"

--- a/viralqc/api.py
+++ b/viralqc/api.py
@@ -1,13 +1,35 @@
-from fastapi import FastAPI, Query, HTTPException
+from fastapi import FastAPI, Query, HTTPException, UploadFile, File
 from viralqc.core.datasets import GetNextcladeDatasets
-from viralqc import GET_NC_PUBLIC_DATASETS_SNK_PATH, DATASETS_CONFIG_PATH
+from pathlib import Path
+from uuid import uuid4
+from json import load
+from viralqc.core.run_nextclade import RunNextclade
+from viralqc import (
+    DATASETS_CONFIG_PATH,
+    GET_NC_PUBLIC_DATASETS_SNK_PATH,
+    RUN_NEXTCLADE_SNK_PATH,
+)
 
 app = FastAPI(
     title="ViralQC Example API",
-    description="A demo REST API for the viralQA.",
+    description="A REST API for the viralQC.",
 )
 
 get_nc_datasets = GetNextcladeDatasets()
+run_nextclade = RunNextclade()
+
+
+def _get_tmp_dir_uuid() -> Path:
+    tmp_dir = Path("/tmp/vqc") / str(uuid4())
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    return tmp_dir
+
+
+def _save_input_file(content: str, dir: Path) -> Path:
+    file_path = dir / "input.fasta"
+    with open(file_path, "wb") as f:
+        f.write(content)
+    return file_path
 
 
 @app.get("/")
@@ -15,8 +37,8 @@ def root():
     return {"message": "Welcome to ViralQC API!"}
 
 
-@app.get("/get_nextclade_datasets")
-def get_nextclade_datasets(cores: int = Query(...)):
+@app.post("/get_nextclade_datasets")
+def get_nextclade_datasets(cores: int = Query(1, description="Number of cores to use")):
     """Get nextclade datasets"""
     snakemake_response = get_nc_datasets.get_public_dataset(
         datasets_dir="datasets",
@@ -26,6 +48,46 @@ def get_nextclade_datasets(cores: int = Query(...)):
     )
     if snakemake_response.status == 200:
         return {"result": snakemake_response.format_log()}
+    else:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Snakemake execution error: {str(snakemake_response.format_log())}",
+        )
+
+
+@app.post("/run")
+async def run(
+    sequences_fasta: UploadFile = File(...),
+    cores: int = Query(1, description="Number of cores to use"),
+    nextclade_sort_min_score: float = Query(
+        0.1, description="Nextclade sort min score."
+    ),
+    nextclade_sort_min_hits: int = Query(10, description="Nextclade sort min hits."),
+):
+    output_directory = _get_tmp_dir_uuid()
+    file_binary_content = await sequences_fasta.read()
+    input_file = _save_input_file(file_binary_content, output_directory)
+    snakemake_response = run_nextclade.run(
+        snk_file=RUN_NEXTCLADE_SNK_PATH,
+        config_file=DATASETS_CONFIG_PATH,
+        cores=cores,
+        sequences_fasta=input_file,
+        sort_mode="nextclade",
+        output_dir=output_directory,
+        output_file="results.json",
+        datasets_local_path="datasets",
+        nextclade_sort_min_score=nextclade_sort_min_score,
+        nextclade_sort_min_hits=nextclade_sort_min_hits,
+        blast_database="",
+    )
+    with open(f"{output_directory}/results.json", "r") as f:
+        results_data = load(f)
+    if snakemake_response.status == 200:
+        return {
+            "log": snakemake_response.format_log(),
+            "tmp_results_path": output_directory,
+            "results": results_data,
+        }
     else:
         raise HTTPException(
             status_code=500,

--- a/viralqc/api.py
+++ b/viralqc/api.py
@@ -64,6 +64,7 @@ async def run(
     ),
     nextclade_sort_min_hits: int = Query(10, description="Nextclade sort min hits."),
 ):
+    """Run viralQC given an input fasta file."""
     output_directory = _get_tmp_dir_uuid()
     file_binary_content = await sequences_fasta.read()
     input_file = _save_input_file(file_binary_content, output_directory)

--- a/viralqc/scripts/python/post_process_nextclade.py
+++ b/viralqc/scripts/python/post_process_nextclade.py
@@ -82,7 +82,7 @@ def _parse_cds_cov(cds_list: str) -> list[dict[str, float]]:
     result = {}
     for p in parts:
         cds, cov = p.split(":")
-        result[cds] = float(cov)
+        result[cds] = round(float(cov), 4)
     return result
 
 
@@ -248,7 +248,7 @@ def write_combined_df(
         combined_df[TARGET_COLUMNS.keys()]
         .astype(TARGET_COLUMNS)
         .sort_values(by=["virus"])
-    )
+    ).round(4)
 
     if output_format == "tsv":
         final_df.to_csv(output_file, sep="\t", index=False, header=True)


### PR DESCRIPTION
Atrelado a este card https://app.asana.com/1/1204612149853114/project/1209099182728391/task/1211203042156162?focus=true

Adiciona o endpoint para rodar o viralQC no modulo de API.

Alguns ajustes feitos:

- Atualização do readme para inclusão da forma de instalação via pip, disponível agora em https://pypi.org/project/viralQC/
- Atualização do .toml para colocar a primeira versão publicada no pypi como 0.1.0 (primeira minor, não considerada uma versão fechada 1.0.0) e inclusão do status de desenvolvimento como Alpha
- Ajuste dos floats no output do viral qc para 4 casas decimais


Sobre o endpoint, algumas considerações:

- Não incluí ainda nenhuma task de validação do fasta no endpoint, pois imagino que o locus ja faça isso, vejo a inclusão disso futuramente, pensando em outros usuários
- Configurei de modo ao viralqc criar um diretório em `/tmp/` com um código de `uuid` evitando sobreposição de resultados, podemos discutir se tem uma melhor prática para isto.

Testei instalar e rodar o viralQC via pip, e deu certo