### PR TITLE
fix: setuptools version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM mambaorg/micromamba:1.5.1
+
+USER root
+ENV PATH="/opt/conda/bin:$PATH"
+
+WORKDIR /app
+ENV DATASETS_DIR="/app/datasets"
+
+RUN apt-get update && apt-get install -y unzip && apt-get clean
+
+RUN micromamba install -y -n base \
+    -c conda-forge \
+    -c bioconda \
+    snakemake-minimal=7.32.4 \
+    blast=2.16.0 \
+    nextclade=3.15.0 \
+    seqtk=1.5 \
+    ncbi-datasets-cli=18.9.0 \
+    taxonkit=0.20.0 \
+    pip && \
+    micromamba clean -ay
+
+RUN pip install viralQC
+
+RUN set -eo pipefail && \
+    vqc get-nextclade-datasets --datasets-dir $DATASETS_DIR -v && \
+    vqc get-blast-database --output-dir $DATASETS_DIR -v
+
+ENTRYPOINT ["vqc"]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -76,3 +76,40 @@ pip install -e .
 ```bash
 vqc --help
 ```
+
+## Docker
+
+We provide a Dockerfile to build a container with all the dependencies installed as well as with the viralQC datasets.
+
+### Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/InstitutoTodosPelaSaude/viralQC.git
+cd viralQC
+```
+
+### Step 2: Build the Docker Image
+
+```bash
+docker build -t vqc .
+```
+
+### Step 3: Verify Installation
+
+```bash
+docker run vqc --help
+```
+
+### Step 4: Run viralQC
+
+You can run viralQC using the following command:
+
+```bash
+ docker run \
+  -v $(pwd)/test_data:/app/test_data \
+  -v $(pwd)/test_outputs:/app/outputs \
+  vqc run \
+  --input /app/test_data/sequences.fasta -v
+```
+
+Where the volumes of input and output directories are mounted to the container.

--- a/env.yml
+++ b/env.yml
@@ -13,3 +13,4 @@ dependencies:
 - python>=3.8.0,<3.12.0
 - seqtk>=1.5.0,<1.6.0
 - taxonkit>=0.20.0,<0.21.0
+- setuptools=70

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "viralQC"
-version = "0.13.0"
+version = "0.13.1"
 description = "A tool and package for quality control of consensus virus genomes."
 authors = [
     { name = "Filipe Zimmer Dezordi", email = "zimmer.filipe@gmail.com" }


### PR DESCRIPTION
A versão do setuptools nos canais do conda atualizou, removendo o módulo `pkg_resources`, o que quebra o import dentro do snakemake gerando o erro `ModuleNotFoundError: No module named 'pkg_resources'`.

Esse hotfix limita a versão do setuptools para manter a última versão que possui o método `pkg_resources`